### PR TITLE
Add compression for build release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,15 @@ make raspi_3.img
 # copy to releases
 TODAY=$(date +"%Y%m%d")
 RELEASE_DIR=/var/www/releases.peachcloud.org/html/peach-imgs/$TODAY
-echo "++ successful image build, copying output to ${RELEASE_DIR}"
 mkdir -p $RELEASE_DIR
-cp raspi_3.img $RELEASE_DIR/${TODAY}_peach_raspi3.img
+echo "++ successful image build, performing compression"
+xz -k raspi.img
+status=$?
+if [ $status -eq 0  ]; then
+    echo "++ compression successful, copying compressed img to ${RELEASE_DIR}"
+    cp raspi_3.img.xz $RELEASE_DIR/${TODAY}_peach_raspi3.img.xz
+else
+    echo "++ compression failed, copying uncompressed img to ${RELEASE_DIR}"
+    cp raspi_3.img $RELEASE_DIR/${TODAY}_peach_raspi3.img
+fi
 cp raspi_3.log $RELEASE_DIR/${TODAY}_peach_raspi3.log


### PR DESCRIPTION
@mhfowler 

Using `xz` with the default compression level (`-6`), I was able to get the 2.1 GB image down to 477.2 MB. I think this is a great improvement with minimal change to the build process.

One thing I'd love your opinion on is the way I've handled the failure state for the compression. I highly doubt the compression will ever fail, but if it does then the uncompressed release image is simply copied to the `RELEASE_DIR` instead of the compressed image.